### PR TITLE
Not deleting files in development mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -175,6 +175,7 @@ function onDownloadCompleted(configuration, dest, version)
   } catch (e) {
     console.error("Unable to manage steam upload for: " + e.message);
   } finally {
+    if(process.env.NODE_ENV == "development") return;
     removeBuild(configuration.inputDir);
     removeBuild(configuration.outputDir);
     tryToRemoveTempFile(dest);


### PR DESCRIPTION
When NODE_ENV=development is set in the .env file don't delete the content folders of the builds. Doing so it's easier to debug if something is gone wrong.