### PR TITLE
Unzipping excluding files that shouldn't be shipped

### DIFF
--- a/app.js
+++ b/app.js
@@ -185,7 +185,7 @@ function decompressBuild(filename, inputDir)
 {
   console.log('Decompressing build...');
   try {
-    execSync(`unzip -o ${filename} -d ${inputDir}`);
+    execSync(`unzip -o ${filename} -d ${inputDir} -x "*.pdb" "*_BurstDebugInformation_DoNotShip/*" "*_BackUpThisFolder_ButDontShipItWithYourGame/*"`);
   } catch (error) {
     throw new Error('Unzip failed with error %s', error.message);
   }


### PR DESCRIPTION
This resolves #8, when unzipping we exclude a list of files that shouldn't be pushed.

Referenced from another library that does the same thing but with git actions: https://github.com/game-ci/steam-deploy