### PR TITLE
pointing toward new documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Node app that will listen for build events from Unity Cloud Build, download the build, then upload to Steam.
+# SteamDeployPublic
+SteamDeployPublic is a simple node app that you can deploy anywhere that will listen for build events from Unity Cloud Build, download the build, then upload to Steam. This will give yo a simple but working full pipeline.
 
-Documentation:
-https://docs.google.com/document/d/1DNN_f_H4PZaLjKnIx4oS2husR41oDSth673lMsc9jyo/edit?usp=sharing
-
+**Documentation:**  
+https://github.com/alanlawrance/steam-deploy-public/wiki


### PR DESCRIPTION
Just changed the readme to point toward the wiki. I copied all your documentation and just added the security bits. the new configuration file and the drm part. It could use a grammar check but beside this the rest has been left untouched (beside moving a chapter above the other)